### PR TITLE
fix waiting for cleanup pods

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -15,7 +15,6 @@ test:
 
 deployment:
   master:
-    #branch: master
-    branch: fix-wait-for-cleanup
+    branch: master
     commands:
       - ./architect deploy


### PR DESCRIPTION
There was a race. Usually number of pods selected was 0 because the
select was performed before pods were scheduled by
ReplicationController.