### PR TITLE
increase memory to 200Mi

### DIFF
--- a/kubernetes/deployment.yaml
+++ b/kubernetes/deployment.yaml
@@ -37,9 +37,9 @@ spec:
         resources:
           requests:
             cpu: 100m
-            memory: 20Mi
+            memory: 200Mi
           limits:
             cpu: 250m
-            memory: 20Mi
+            memory: 200Mi
       imagePullSecrets:
       - name: giantswarm-registry


### PR DESCRIPTION
Otherwise `apk --update add curl` takes too much memory.

I treat previous value as a test if it able to survive on such low memory footprint (20Mi). It is. There isn't a reason to restart the operator container every so often bc of OOMs.