### PR TITLE
ntp-can-be-hostname

### DIFF
--- a/service/flannel/keys.go
+++ b/service/flannel/keys.go
@@ -91,7 +91,7 @@ func networkInterfaceName(spec flanneltpr.Spec) string {
 func networkNTPBlock(spec flanneltpr.Spec) string {
 	var parts []string
 	for _, s := range spec.Bridge.Spec.NTP.Servers {
-		parts = append(parts, fmt.Sprintf("NTP=%s", s.String()))
+		parts = append(parts, fmt.Sprintf("NTP=%s", s))
 	}
 	return strings.Join(parts, "\n")
 }

--- a/vendor/github.com/giantswarm/flanneltpr/spec/bridge/spec/ntp.go
+++ b/vendor/github.com/giantswarm/flanneltpr/spec/bridge/spec/ntp.go
@@ -1,7 +1,5 @@
 package spec
 
-import "net"
-
 type NTP struct {
-	Servers []net.IP `json:"servers" yaml:"servers"`
+	Servers []string `json:"servers" yaml:"servers"`
 }


### PR DESCRIPTION
ntp-can-be-hostname - changing type from  `net.IP` to `string` 