### PR TITLE
define flanneld version in flannel-operator to keep version bundle in sync

### DIFF
--- a/service/resource/legacy/daemonset.go
+++ b/service/resource/legacy/daemonset.go
@@ -55,7 +55,7 @@ func newDaemonSetContainers(spec flanneltpr.Spec, etcdCAFile, etcdCrtFile, etcdK
 	return []api.Container{
 		{
 			Name:            "flanneld",
-			Image:           flannelDockerImage(spec),
+			Image:           "quay.io/giantswarm/flannel:v0.9.0-amd64",
 			ImagePullPolicy: api.PullAlways,
 			Command: []string{
 				"/bin/sh",

--- a/service/resource/legacy/keys.go
+++ b/service/resource/legacy/keys.go
@@ -4,8 +4,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/giantswarm/flanneltpr"
 	"strconv"
+
+	"github.com/giantswarm/flanneltpr"
 )
 
 const (
@@ -67,10 +68,6 @@ func etcdNetworkPath(spec flanneltpr.Spec) string {
 
 func etcdPrefix(spec flanneltpr.Spec) string {
 	return "/" + etcdNetworkPath(spec)
-}
-
-func flannelDockerImage(spec flanneltpr.Spec) string {
-	return spec.Flannel.Docker.Image
 }
 
 func flannelRunDir(spec flanneltpr.Spec) string {

--- a/service/version_bundles.go
+++ b/service/version_bundles.go
@@ -19,7 +19,7 @@ func NewVersionBundles() []versionbundle.Bundle {
 			Components: []versionbundle.Component{
 				{
 					Name:    "flannel",
-					Version: "0.7.1",
+					Version: "0.9.0",
 				},
 			},
 			Dependencies: []versionbundle.Dependency{


### PR DESCRIPTION
This PR is motivated due to https://github.com/giantswarm/kubernetesd/pull/293. We are migrating towards the usage of version bundles that operators define. That means an operator that defines a version has the responsibility to make sure this version is supported. Thus such versions must not be defined by others (like `kubernetesd` in this case). This PR hard codes the flanneld image/version within the `flannel-operator`. I will provide a PR to cleanup `kubernetesd` and `clustertpr`. 