### PR TITLE
Add rbac and psp files

### DIFF
--- a/helm/flannel-operator-chart/templates/deployment.yaml
+++ b/helm/flannel-operator-chart/templates/deployment.yaml
@@ -26,6 +26,7 @@ spec:
           items:
             - key: config.yaml
               path: config.yaml
+      serviceAccountName: flannel-operator
       containers:
       - name: flannel-operator
         image: quay.io/giantswarm/flannel-operator:[[ .SHA ]]

--- a/helm/flannel-operator-chart/templates/psp.yaml
+++ b/helm/flannel-operator-chart/templates/psp.yaml
@@ -1,0 +1,21 @@
+apiVersion: extensions/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: flannel-operator-psp
+spec:
+  privileged: true
+  fsGroup:
+    rule: RunAsAny
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  volumes:
+    - 'secret'
+    - 'configMap'
+    - 'hostPath'
+  hostNetwork: true
+  hostIPC: false
+  hostPID: false

--- a/helm/flannel-operator-chart/templates/rbac.yaml
+++ b/helm/flannel-operator-chart/templates/rbac.yaml
@@ -1,0 +1,118 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: flannel-operator
+rules:
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - "*"
+  - apiGroups:
+      - core.giantswarm.io
+    resources:
+      - flannelconfigs
+    verbs:
+      - "*"
+  - apiGroups:
+      - extensions
+    resources:
+      - daemonsets
+    verbs:
+      - "*"
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    verbs:
+      - get
+      - list
+      - create
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+      - create
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - serviceaccounts
+    verbs:
+      - create
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - clusterrolebindings
+    verbs:
+      - create
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - list
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    resourceNames:
+      - flannel-operator-configmap
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+  - nonResourceURLs:
+      - "/"
+      - "/healthz"
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: flannel-operator
+subjects:
+  - kind: ServiceAccount
+    name: flannel-operator
+    namespace: giantswarm
+roleRef:
+  kind: ClusterRole
+  name: flannel-operator
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: flannel-operator-psp
+rules:
+  - apiGroups:
+      - extensions
+    resources:
+      - podsecuritypolicies
+    verbs:
+      - use
+    resourceNames:
+      - flannel-operator-psp
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: flannel-operator-psp
+subjects:
+  - kind: ServiceAccount
+    name: flannel-operator
+    namespace: giantswarm
+roleRef:
+  kind: ClusterRole
+  name: flannel-operator-psp
+  apiGroup: rbac.authorization.k8s.io

--- a/helm/flannel-operator-chart/templates/service-account.yaml
+++ b/helm/flannel-operator-chart/templates/service-account.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: flannel-operator
+  namespace: giantswarm


### PR DESCRIPTION
Towards [#2296](https://github.com/giantswarm/giantswarm/issues/2296)

Add service account, cluster roles, bindings and pod security policies to flannel operator (helm). Modify deployment to use the correct service account.

(Split part of https://github.com/giantswarm/giantswarm/issues/1975)