### PR TITLE
Add service account for the deletion namespace

### DIFF
--- a/service/resource/legacyv2/keys.go
+++ b/service/resource/legacyv2/keys.go
@@ -126,3 +126,7 @@ func networkNTPBlock(spec v1alpha1.FlannelConfigSpec) string {
 func networkTapName(spec v1alpha1.FlannelConfigSpec) string {
 	return "tap-" + clusterID(spec)
 }
+
+func serviceAccountNameForDeletion(spec v1alpha1.FlannelConfigSpec) string {
+	return clusterID(spec)
+}

--- a/service/resource/legacyv2/keys.go
+++ b/service/resource/legacyv2/keys.go
@@ -126,7 +126,3 @@ func networkNTPBlock(spec v1alpha1.FlannelConfigSpec) string {
 func networkTapName(spec v1alpha1.FlannelConfigSpec) string {
 	return "tap-" + clusterID(spec)
 }
-
-func serviceAccountNameForDeletion(spec v1alpha1.FlannelConfigSpec) string {
-	return clusterID(spec)
-}

--- a/service/resource/legacyv2/resource.go
+++ b/service/resource/legacyv2/resource.go
@@ -234,7 +234,7 @@ func (r *Resource) newDeleteChange(ctx context.Context, obj, currentState, desir
 
 	// Create a service account for the cleanup job.
 	{
-		serviceAccount := newServiceAccount(customObject, serviceAccountNameForDeletion(spec))
+		serviceAccount := newServiceAccount(customObject, keyv2.ClusterID(customObject))
 		_, err := r.k8sClient.CoreV1().ServiceAccounts(destroyerNamespace(spec)).Create(serviceAccount)
 		if apierrors.IsAlreadyExists(err) {
 			r.logger.Log("debug", "serviceAccount "+serviceAccount.Name+" already exists", "event", "add", "cluster", spec.Cluster.ID)

--- a/service/resource/legacyv2/service_account.go
+++ b/service/resource/legacyv2/service_account.go
@@ -7,8 +7,6 @@ import (
 )
 
 func newServiceAccount(customObject v1alpha1.FlannelConfig, name string) *api.ServiceAccount {
-	app := networkApp
-
 	serviceAccount := &api.ServiceAccount{
 		TypeMeta: apismeta.TypeMeta{
 			Kind:       "ServiceAccount",
@@ -17,7 +15,7 @@ func newServiceAccount(customObject v1alpha1.FlannelConfig, name string) *api.Se
 		ObjectMeta: apismeta.ObjectMeta{
 			Name: name,
 			Labels: map[string]string{
-				"app":         app,
+				"app":         networkApp,
 				"cluster-id":  clusterName(customObject.Spec),
 				"customer-id": clusterCustomer(customObject.Spec),
 			},

--- a/service/resource/legacyv2/service_account.go
+++ b/service/resource/legacyv2/service_account.go
@@ -1,0 +1,28 @@
+package legacyv2
+
+import (
+	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
+	api "k8s.io/api/core/v1"
+	apismeta "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func newServiceAccount(customObject v1alpha1.FlannelConfig, name string) *api.ServiceAccount {
+	app := networkApp
+
+	serviceAccount := &api.ServiceAccount{
+		TypeMeta: apismeta.TypeMeta{
+			Kind:       "ServiceAccount",
+			APIVersion: "v1",
+		},
+		ObjectMeta: apismeta.ObjectMeta{
+			Name: name,
+			Labels: map[string]string{
+				"app":         app,
+				"cluster-id":  clusterName(customObject.Spec),
+				"customer-id": clusterCustomer(customObject.Spec),
+			},
+		},
+	}
+
+	return serviceAccount
+}


### PR DESCRIPTION
Towards [#2296](https://github.com/giantswarm/giantswarm/issues/2296)

Add service account for the deletion namespace (guest cluster is deleted)

(Split part of https://github.com/giantswarm/giantswarm/issues/1975)