### PR TITLE
Align certificate path

### DIFF
--- a/helm/flannel-operator-chart/templates/deployment.yaml
+++ b/helm/flannel-operator-chart/templates/deployment.yaml
@@ -19,7 +19,7 @@ spec:
       volumes:
       - name: etcd-certs
         hostPath:
-          path: /etc/giantswarm/g8s/ssl/etcd/
+          path: /etc/kubernetes/ssl/etcd/
       - name: flannel-operator-configmap
         configMap:
           name: flannel-operator-configmap

--- a/service/flannelconfig/v2/resource/flanneld/desired.go
+++ b/service/flannelconfig/v2/resource/flanneld/desired.go
@@ -303,7 +303,7 @@ func newDaemonSet(customObject v1alpha1.FlannelConfig, etcdCAFile, etcdCrtFile, 
 							Name: "etcd-certs",
 							VolumeSource: corev1.VolumeSource{
 								HostPath: &corev1.HostPathVolumeSource{
-									Path: "/etc/giantswarm/g8s/ssl/etcd",
+									Path: "/etc/kubernetes/ssl/etcd",
 								},
 							},
 						},

--- a/service/flannelconfig/v2/resource/legacy/daemonset.go
+++ b/service/flannelconfig/v2/resource/legacy/daemonset.go
@@ -286,7 +286,7 @@ func newDaemonSetVolumes(spec v1alpha1.FlannelConfigSpec) []api.Volume {
 			Name: "etcd-certs",
 			VolumeSource: api.VolumeSource{
 				HostPath: &api.HostPathVolumeSource{
-					Path: "/etc/giantswarm/g8s/ssl/etcd",
+					Path: "/etc/kubernetes/ssl/etcd",
 				},
 			},
 		},

--- a/service/flannelconfig/v2/resource/legacy/job.go
+++ b/service/flannelconfig/v2/resource/legacy/job.go
@@ -68,7 +68,7 @@ func newJob(spec v1alpha1.FlannelConfigSpec, replicas int32) *batchv1.Job {
 							Name: "etcd-certs",
 							VolumeSource: apiv1.VolumeSource{
 								HostPath: &apiv1.HostPathVolumeSource{
-									Path: "/etc/giantswarm/g8s/ssl/etcd/",
+									Path: "/etc/kubernetes/ssl/etcd/",
 								},
 							},
 						},


### PR DESCRIPTION
Certificates are to be found from /etc/kubernetes/ssl now.

This is part of https://github.com/giantswarm/hive/issues/17

**NOTE:**
I was a bit unsure here if this requires version bump or not. I consider this change as implementation detail as this does not change interface in any way, but on the other hand one would need to know version where this change is applied so that referenced story can be completed fully.