### PR TITLE
remove-etcd-dep

### DIFF
--- a/service/flannelconfig/v2/version_bundle.go
+++ b/service/flannelconfig/v2/version_bundle.go
@@ -21,16 +21,11 @@ func VersionBundle() versionbundle.Bundle {
 				Version: "0.9.0",
 			},
 		},
-		Dependencies: []versionbundle.Dependency{
-			{
-				Name:    "etcd",
-				Version: "<= 3.2.x",
-			},
-		},
-		Deprecated: false,
-		Name:       "flannel-operator",
-		Time:       time.Date(2017, time.October, 27, 16, 21, 0, 0, time.UTC),
-		Version:    "0.1.0",
-		WIP:        false,
+		Dependencies: []versionbundle.Dependency{},
+		Deprecated:   false,
+		Name:         "flannel-operator",
+		Time:         time.Date(2017, time.October, 27, 16, 21, 0, 0, time.UTC),
+		Version:      "0.1.0",
+		WIP:          false,
 	}
 }


### PR DESCRIPTION
Removing the dependency on etcd version as flannel-operator is connecting to host cluster etcd and not guest cluster etcd 

We still need to be sure that we have compatible version etcd client version and host cluster etcd, but that cant be easily done via version bundles.