### PR TITLE
Deprecate v2 so there's only one active version

### DIFF
--- a/service/controller/v2/version_bundle.go
+++ b/service/controller/v2/version_bundle.go
@@ -22,7 +22,7 @@ func VersionBundle() versionbundle.Bundle {
 			},
 		},
 		Dependencies: []versionbundle.Dependency{},
-		Deprecated:   false,
+		Deprecated:   true,
 		Name:         "flannel-operator",
 		Time:         time.Date(2017, time.October, 27, 16, 21, 0, 0, time.UTC),
 		Version:      "0.1.0",


### PR DESCRIPTION
When I created a new version bundle together with certificate path aligning, I made a mistake and accidentally release v3 as non-WIP as well. As an end result there were two active releases for flannel-operator. Deprecate v2 now and continue with v3.