### PR TITLE
Move checksum annotation to POD metadata

### DIFF
--- a/helm/flannel-operator-chart/templates/deployment.yaml
+++ b/helm/flannel-operator-chart/templates/deployment.yaml
@@ -5,8 +5,6 @@ metadata:
   namespace: giantswarm
   labels:
     app: flannel-operator
-  annotations:
-    checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
 spec:
   replicas: 1
   revisionHistoryLimit: 3
@@ -16,6 +14,8 @@ spec:
     metadata:
       labels:
         app: flannel-operator
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
     spec:
       hostNetwork: true
       volumes:

--- a/helm/flannel-operator-chart/templates/deployment.yaml
+++ b/helm/flannel-operator-chart/templates/deployment.yaml
@@ -12,10 +12,10 @@ spec:
     type: RollingUpdate
   template:
     metadata:
-      labels:
-        app: flannel-operator
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+      labels:
+        app: flannel-operator
     spec:
       hostNetwork: true
       volumes:


### PR DESCRIPTION
As given example in Helm FAQ, this checksum should be in POD metadata.

Fixes issue noted here: https://github.com/giantswarm/giantswarm/issues/3022#issuecomment-384255822