### PR TITLE
Update microkit dep & enable debug server

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -138,7 +138,7 @@
     "tls",
   ]
   pruneopts = "UT"
-  revision = "6d9fca5cdb031ccb8712dbe465b1fc4bd9ad6c52"
+  revision = "21181e2cc3c8f5ce7aa32dfdd38aa11643a0a5bf"
 
 [[projects]]
   branch = "master"

--- a/helm/flannel-operator-chart/templates/configmap.yaml
+++ b/helm/flannel-operator-chart/templates/configmap.yaml
@@ -6,6 +6,9 @@ metadata:
 data:
   config.yaml: |
     server:
+      enable:
+        debug:
+          server: true
       listen:
         address: 'http://0.0.0.0:8000'
     service:


### PR DESCRIPTION
Added debug server exposes net/http/pprof interface in
http://127.0.0.1:6060/debug.

This helps with profiling running service e.g. when it's OOMing.

Towards https://github.com/giantswarm/giantswarm/issues/4088