### PR TITLE
Add CRD label selector for e2e tests

### DIFF
--- a/flag/service/crd/crd.go
+++ b/flag/service/crd/crd.go
@@ -1,0 +1,5 @@
+package crd
+
+type CRD struct {
+	LabelSelector string
+}

--- a/flag/service/service.go
+++ b/flag/service/service.go
@@ -1,11 +1,13 @@
 package service
 
 import (
+	"github.com/giantswarm/flannel-operator/flag/service/crd"
 	"github.com/giantswarm/flannel-operator/flag/service/etcd"
 	"github.com/giantswarm/flannel-operator/flag/service/kubernetes"
 )
 
 type Service struct {
+	CRD        crd.CRD
 	Etcd       etcd.Etcd
 	Kubernetes kubernetes.Kubernetes
 }

--- a/helm/flannel-operator-chart/templates/configmap.yaml
+++ b/helm/flannel-operator-chart/templates/configmap.yaml
@@ -12,6 +12,8 @@ data:
       listen:
         address: 'http://0.0.0.0:8000'
     service:
+      crd:
+        labelSelector: '{{ .Values.service.crd.labelSelector }}'
       etcd:
         endpoint: 'https://127.0.0.1:2379'
         tls:

--- a/helm/flannel-operator-chart/values.yaml
+++ b/helm/flannel-operator-chart/values.yaml
@@ -1,1 +1,4 @@
 namespace: giantswarm
+service:
+  crd:
+    labelSelector: ''

--- a/main.go
+++ b/main.go
@@ -97,6 +97,8 @@ func main() {
 
 	daemonCommand := newCommand.DaemonCommand().CobraCommand()
 
+	daemonCommand.PersistentFlags().String(f.Service.CRD.LabelSelector, "", "Label selector for CRD informer ListOptions.")
+
 	daemonCommand.PersistentFlags().String(f.Service.Etcd.Endpoint, "http://127.0.0.1:2379", "Endpoint used to connect to host's etcd.")
 	daemonCommand.PersistentFlags().String(f.Service.Etcd.TLS.CAFile, "", "Certificate authority file path to use to authenticate with etcd.")
 	daemonCommand.PersistentFlags().String(f.Service.Etcd.TLS.CrtFile, "", "Certificate file path to use to authenticate with etcd.")

--- a/service/controller/network.go
+++ b/service/controller/network.go
@@ -8,6 +8,7 @@ import (
 	"github.com/giantswarm/operatorkit/client/k8scrdclient"
 	"github.com/giantswarm/operatorkit/controller"
 	"github.com/giantswarm/operatorkit/informer"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/giantswarm/flannel-operator/service/controller/v2"
@@ -20,11 +21,20 @@ type NetworkConfig struct {
 	G8sClient versioned.Interface
 	Logger    micrologger.Logger
 
-	CAFile       string
-	CrtFile      string
-	EtcdEndpoint string
-	KeyFile      string
-	ProjectName  string
+	CAFile           string
+	CrtFile          string
+	CRDLabelSelector string
+	EtcdEndpoint     string
+	KeyFile          string
+	ProjectName      string
+}
+
+func (c NetworkConfig) newInformerListOptions() metav1.ListOptions {
+	listOptions := metav1.ListOptions{
+		LabelSelector: c.CRDLabelSelector,
+	}
+
+	return listOptions
 }
 
 type Network struct {
@@ -44,6 +54,7 @@ func NewNetwork(config NetworkConfig) (*Network, error) {
 			Logger:  config.Logger,
 			Watcher: config.G8sClient.CoreV1alpha1().FlannelConfigs(""),
 
+			ListOptions:  config.newInformerListOptions(),
 			RateWait:     informer.DefaultRateWait,
 			ResyncPeriod: informer.DefaultResyncPeriod,
 		}

--- a/service/service.go
+++ b/service/service.go
@@ -127,11 +127,12 @@ func New(config Config) (*Service, error) {
 			K8sClient: k8sClient,
 			Logger:    config.Logger,
 
-			CAFile:       config.Viper.GetString(config.Flag.Service.Etcd.TLS.CAFile),
-			CrtFile:      config.Viper.GetString(config.Flag.Service.Etcd.TLS.CrtFile),
-			EtcdEndpoint: config.Viper.GetString(config.Flag.Service.Etcd.Endpoint),
-			KeyFile:      config.Viper.GetString(config.Flag.Service.Etcd.TLS.KeyFile),
-			ProjectName:  config.Name,
+			CAFile:           config.Viper.GetString(config.Flag.Service.Etcd.TLS.CAFile),
+			CrtFile:          config.Viper.GetString(config.Flag.Service.Etcd.TLS.CrtFile),
+			CRDLabelSelector: config.Viper.GetString(config.Flag.Service.CRD.LabelSelector),
+			EtcdEndpoint:     config.Viper.GetString(config.Flag.Service.Etcd.Endpoint),
+			KeyFile:          config.Viper.GetString(config.Flag.Service.Etcd.TLS.KeyFile),
+			ProjectName:      config.Name,
 		}
 
 		networkController, err = controller.NewNetwork(c)


### PR DESCRIPTION
On KVM e2e tests there are multiple instances of operators running at
the same time. In order to prevent race conditions, add label selector
to informer to only process CRs meant for current instance of operator.

Towards https://github.com/giantswarm/giantswarm/issues/4196#issuecomment-421297710