### PR TITLE
Use host PID namespace

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  architect: giantswarm/architect@0.8.12
+  architect: giantswarm/architect@0.10.0
 
 workflows:
   build:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Stop ensuring `FlannelConfig` on start up.
+- Use host PID namespace for flannel-network DS and flannel-destroyer Job.
 
 ## [1.1.1] - 2020-04-29
 

--- a/service/controller/v3/resource/flanneld/desired.go
+++ b/service/controller/v3/resource/flanneld/desired.go
@@ -89,6 +89,7 @@ func newDaemonSet(customObject v1alpha1.FlannelConfig, etcdEndpoints []string, e
 				},
 				Spec: corev1.PodSpec{
 					HostNetwork: true,
+					HostPID:     true,
 					Containers: []corev1.Container{
 						{
 							Name:            "flanneld",

--- a/service/controller/v3/resource/legacy/job.go
+++ b/service/controller/v3/resource/legacy/job.go
@@ -41,6 +41,7 @@ func newJob(customObject v1alpha1.FlannelConfig, replicas int32) *batchv1.Job {
 					ServiceAccountName: serviceAccountName(customObject.Spec),
 					RestartPolicy:      apiv1.RestartPolicyOnFailure,
 					HostNetwork:        true,
+					HostPID:            true,
 					Volumes: []apiv1.Volume{
 						{
 							Name: "cgroup",


### PR DESCRIPTION
This allows `k8s-network-bridge` to run `systemctl` within its container. `systemctl` doesn't support running inside a PID namespace as of systemd v237. This is required to upgrade the `k8s-network-bridge` base image to Fedora 28+.

## Checklist

- [x] Update changelog in CHANGELOG.md.
